### PR TITLE
Fix ex mode history error in Neovim

### DIFF
--- a/lua/sluice/plugins/matchlist.lua
+++ b/lua/sluice/plugins/matchlist.lua
@@ -11,7 +11,9 @@ function M.update(settings, winid)
   local lines = M.vim.api.nvim_buf_get_lines(bufnr, 0, -1, true)
 
   for lnum, line in pairs(lines) do
-    if M.vim.fn.match(line, pattern) ~= -1 then
+    -- Convert to string to handle special buffers (e.g., ex history) that may return Blob objects
+    local line_str = tostring(line)
+    if M.vim.fn.match(line_str, pattern) ~= -1 then
       table.insert(lines_with_matches, {
         lnum = lnum,
         text = "/ ",
@@ -37,7 +39,9 @@ function M.update(settings, winid)
   local lines = M.vim.api.nvim_buf_get_lines(bufnr, 0, -1, true)
 
   for lnum, line in pairs(lines) do
-    if M.vim.fn.match(line, pattern) ~= -1 then
+    -- Convert to string to handle special buffers (e.g., ex history) that may return Blob objects
+    local line_str = tostring(line)
+    if M.vim.fn.match(line_str, pattern) ~= -1 then
       table.insert(lines_with_matches, {
         lnum = lnum,
         text = "/ ",

--- a/lua/sluice/plugins/search.lua
+++ b/lua/sluice/plugins/search.lua
@@ -72,7 +72,9 @@ function M.new(plugin_settings, winid)
     local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, true)
 
     for lnum, line in pairs(lines) do
-      if vim.fn.match(line, pattern) ~= -1 then
+      -- Convert to string to handle special buffers (e.g., ex history) that may return Blob objects
+      local line_str = tostring(line)
+      if vim.fn.match(line_str, pattern) ~= -1 then
         local texthl = search.settings.match_hl
         if lnum == current_line then
           texthl = search.settings.match_line_hl


### PR DESCRIPTION
In Neovim 0.11.5, nvim_buf_get_lines() returns Blob objects instead of strings for special buffers like the ex command history (opened with : then Ctrl-f). This caused E976 errors when vim.fn.match() tried to use these Blob objects as strings.

Convert lines to strings using tostring() before passing them to vim.fn.match() in both search.lua and matchlist.lua plugins.

Fixes error: "E976: Using a Blob as a String"